### PR TITLE
bump version to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-hat-developer-hub/cli",
   "description": "CLI for developing Backstage plugins and apps",
-  "version": "0.0.2",
+  "version": "1.7.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
We have decided to keep the rhdh-cli cli major and minor versions in sync with RHDH release to clearly communicate the compatiblity.