### PR TITLE
chore: tagRelease.sh: bump to 1.8.0 in main branch [skip-build]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-hat-developer-hub/cli",
   "description": "CLI for developing Backstage plugins and apps",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>

generated with code in https://gitlab.cee.redhat.com/rhidp/rhdh/-/merge_requests/296 for https://issues.redhat.com/browse/RHIDP-8182
