### PR TITLE
fix(plugin package): use correct export command

### DIFF
--- a/.changeset/new-grapes-find.md
+++ b/.changeset/new-grapes-find.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/cli': patch
+---
+
+Update "plugin package" command to use the correct export command when exporting a plugin

--- a/src/commands/package-dynamic-plugins/command.ts
+++ b/src/commands/package-dynamic-plugins/command.ts
@@ -124,12 +124,12 @@ export async function command(opts: OptionValues): Promise<void> {
         );
         try {
           await Task.forCommand(
-            `${process.execPath} ${process.argv[1]} package export-dynamic-plugin`,
+            `${process.execPath} ${process.argv[1]} plugin export`,
             { cwd: packageDirectory },
           );
         } catch (err) {
           Task.log(
-            `Encountered an error running 'npx @janus-idp/cli' on plugin package ${packageFilePath}, this plugin will not be packaged.  The error was ${err}`,
+            `Encountered an error running the generated export command on plugin package ${packageFilePath}, this plugin will not be packaged.  The error was ${err}`,
           );
         }
       }


### PR DESCRIPTION
This change updates the "plugin package" command to construct the correct command to export a dynamic plugin in a monorepo.  This change also updates some of the related logging text.