### PR TITLE
fix: more robust entry point validation for backend plugins.

### DIFF
--- a/src/commands/export-dynamic-plugin/backend.ts
+++ b/src/commands/export-dynamic-plugin/backend.ts
@@ -854,6 +854,7 @@ function isPackageShared(
 function validatePluginEntryPoints(target: string): string {
   const dynamicPluginRequire = createRequire(`${target}/package.json`);
 
+  let retryingAfterTsExtensionAdded = false;
   function requireModule(modulePath: string): any {
     try {
       return dynamicPluginRequire(modulePath);
@@ -862,14 +863,14 @@ function validatePluginEntryPoints(target: string): string {
       // because the `ts` require extension was not there.  Else we should
       // throw.
       if (
-        (e?.code !== 'ERR_UNSUPPORTED_DIR_IMPORT' &&
-          e?.name !== SyntaxError.name) ||
+        retryingAfterTsExtensionAdded ||
         dynamicPluginRequire.extensions['.ts'] !== undefined
       ) {
         throw e;
       }
     }
 
+    retryingAfterTsExtensionAdded = true;
     Task.log(
       `  adding typescript extension support to enable entry point validation`,
     );


### PR DESCRIPTION
During the entry point validation step of dynamic backend plugin export, it might be needed to add typescript support to the module loading `require` call, especially when the exported plugin transitively imports typescript source modules of the current monorepo (the backstage/backstage is the typical example).
This PR fixes some cases when typescript wasn't correctly added, resulting in export errors like [the following](https://github.com/redhat-developer/rhdh-plugin-export-overlays/actions/runs/18167722471/job/51714290549#step:17:1507).
