### PR TITLE
chore(ci): switch to npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -30,7 +31,4 @@ jobs:
         run: yarn build
 
       - name: Publish
-        run: yarn npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
## Summary

- Replace long-lived `NPM_TOKEN` secret authentication with OIDC-based
  [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/)
  for improved supply chain security.
- Add `id-token: write` permission to enable GitHub Actions OIDC token generation.
- Switch from `yarn npm publish` to `npm publish` as the npm CLI has
  native OIDC support, while Yarn Berry's support
  [has known issues](https://github.com/yarnpkg/berry/issues/6952).

## Why

npm Trusted Publishing eliminates the need for storing and rotating long-lived
npm access tokens (`NPM_TOKEN`) in CI. Instead, it uses short-lived,
workflow-specific OIDC credentials that cannot be exfiltrated or reused.
Provenance attestations are also generated automatically.

See: https://docs.npmjs.com/trusted-publishers/

## Notes

- The trusted publisher has already been configured on the npm registry for
  `@red-hat-developer-hub/cli`.
- The `NPM_TOKEN` secret can be removed from the repository settings after
  this change is verified.

## Test plan

- [ ] Trigger `publish.yaml` via `workflow_dispatch` and verify successful
      publish to npm with OIDC authentication.
- [ ] Confirm provenance attestation appears on the npm package page.