### PR TITLE
fix(ci): remove registry-url to fix OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          registry-url: 'https://registry.npmjs.org'
           node-version-file: .nvmrc
           cache: 'yarn'
 


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `actions/setup-node` to fix npm trusted publishing.

## Why

The `actions/setup-node` action with `registry-url` creates an `.npmrc` file
containing a token-based auth entry (`_authToken=${NODE_AUTH_TOKEN}`). When
this is present, the npm CLI uses it for authentication instead of falling
back to OIDC, resulting in a misleading `E404 Not Found` error.

See failed run: https://github.com/redhat-developer/rhdh-cli/actions/runs/25049882855/job/73374606348

Reference: https://docs.npmjs.com/trusted-publishers/

## Test plan

- [ ] Trigger `publish.yaml` via `workflow_dispatch` and verify successful
      publish to npm with OIDC authentication.