### PR TITLE
fix(ci): install npm 11+ for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,5 +29,8 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Publish
         run: npm publish --access public


### PR DESCRIPTION
## Summary

- Install `npm@latest` (11.5.1+) before publishing, since Node 22 ships
  with npm 10.x which does not support OIDC authentication.

## Why

npm trusted publishing requires npm CLI 11.5.1+ for OIDC token exchange.
Node 22.22.0 bundles npm 10.9.x, which has no OIDC support, causing
`ENEEDAUTH` errors.

See failed run: https://github.com/redhat-developer/rhdh-cli/actions/runs/25050189102/job/73375641931

Reference: https://docs.npmjs.com/trusted-publishers/

## Test plan

- [ ] Trigger `publish.yaml` via `workflow_dispatch` and verify successful
      publish to npm with OIDC authentication.