### PR TITLE
fix: enhance `backstage:^` dependency version resolution in `searchEmbedded` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@red-hat-developer-hub/cli` are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.10.6 - 2026-04-28
+
+### Fixed
+
+- **`export-dynamic-plugin` backend path:** `backstage:^` resolution now also applies in `searchEmbedded()`, which validates embedded dependency versions before `customizeForDynamicUse` runs. Previously the raw `backstage:^` string was passed directly to `semver.satisfies()`, causing the export to fail for plugins with `backstage:^` on embedded dependencies.
+
 ## 1.10.5 - 2026-04-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-hat-developer-hub/cli",
   "description": "CLI for developing Backstage plugins and apps",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "publishConfig": {
     "access": "public"
   },

--- a/src/commands/export-dynamic-plugin/backend.ts
+++ b/src/commands/export-dynamic-plugin/backend.ts
@@ -549,6 +549,17 @@ async function searchEmbedded(
       if (embedded.includes(dep)) {
         const dependencyVersion = pkg.dependencies[dep];
 
+        let effectiveVersion = dependencyVersion;
+        if (isBackstageVersionSpec(dependencyVersion)) {
+          const resolvedBackstageVersion = await resolveBackstageVersion(
+            dep,
+            dependencyVersion,
+          );
+          if (resolvedBackstageVersion) {
+            effectiveVersion = resolvedBackstageVersion;
+          }
+        }
+
         const relatedMonoRepoPackages = monoRepoPackages.packages.filter(
           p => p.packageJson.name === dep,
         );
@@ -582,7 +593,7 @@ async function searchEmbedded(
           } else if (
             semver.satisfies(
               monoRepoPackage.packageJson.version,
-              dependencyVersion,
+              effectiveVersion,
             )
           ) {
             isResolved = true;
@@ -613,7 +624,7 @@ async function searchEmbedded(
             await fs.readFile(resolvedPackageJson, 'utf8'),
           ) as BackstagePackageJson;
 
-          if (!semver.satisfies(resolvedPackage.version, dependencyVersion)) {
+          if (!semver.satisfies(resolvedPackage.version, effectiveVersion)) {
             throw new Error(
               `Resolved package named '${dep}' at '${resolvedPackageDir}' doesn't satisfy dependency version requirement in parent package '${pkg.name}': '${resolvedPackage.version}', '${dependencyVersion}'.`,
             );


### PR DESCRIPTION
### Enhance `backstage:^` dependency version resolution in `searchEmbedded` function

Updated the `searchEmbedded` function to utilize an effective version for dependencies. This change ensures that if a dependency version is a `backstage:^` version spec, it resolves to the correct version before checking compatibility with related mono-repo packages. This improves the accuracy of dependency resolution and error handling during plugin exports.

Assisted-by: Cursor