### PR TITLE
fix: incomplete implementation of `workspace:`/`backstage:` protocol resolution causes invalid `peerDependencies` and version drift

### DIFF
--- a/.changeset/clever-berries-judge.md
+++ b/.changeset/clever-berries-judge.md
@@ -1,0 +1,5 @@
+---
+'@red-hat-developer-hub/cli': patch
+---
+
+fix: resolve `workspace:/backstage/` protocol specifiers in `peerDependencies` and pin resolved versions in `resolutions` to prevent dependency drift

--- a/src/commands/export-dynamic-plugin/backend.ts
+++ b/src/commands/export-dynamic-plugin/backend.ts
@@ -698,7 +698,7 @@ async function resolveProtocolVersion(
   embedded: ResolvedEmbedded[],
   monoRepoPackages: Packages | undefined,
   contextPkgName: string,
-): Promise<string | undefined> {
+): Promise<{ resolved: string; exact: string } | undefined> {
   if (versionSpec.startsWith('workspace:')) {
     let resolvedVersion: string | undefined;
     const rangeSpecifier = versionSpec.replace(/^workspace:/, '');
@@ -739,10 +739,11 @@ async function resolveProtocolVersion(
       );
     }
 
+    const exact = resolvedVersion;
     if (rangeSpecifier === '^' || rangeSpecifier === '~') {
       resolvedVersion = rangeSpecifier + resolvedVersion;
     }
-    return resolvedVersion;
+    return { resolved: resolvedVersion, exact };
   }
 
   if (isBackstageVersionSpec(versionSpec)) {
@@ -753,7 +754,8 @@ async function resolveProtocolVersion(
           versionSpec,
         )} to ${chalk.green(resolvedVersion)}`,
       );
-      return resolvedVersion;
+      const exact = resolvedVersion.replace(/^[\^~]/, '');
+      return { resolved: resolvedVersion, exact };
     }
   }
 
@@ -791,6 +793,10 @@ export function customizeForDynamicUse(options: {
       f => !f.startsWith('dist-dynamic/'),
     );
 
+    // Collect exact versions for pinning in resolutions
+    const pinnedResolutions: Record<string, string> = {};
+    const embeddedNames = new Set(options.embedded.map(e => e.packageName));
+
     // Resolve workspace: and backstage: in dependencies
     if (pkgToCustomize.dependencies) {
       for (const dep in pkgToCustomize.dependencies) {
@@ -804,15 +810,18 @@ export function customizeForDynamicUse(options: {
         }
 
         const dependencyVersionSpec = pkgToCustomize.dependencies[dep];
-        const resolved = await resolveProtocolVersion(
+        const result = await resolveProtocolVersion(
           dep,
           dependencyVersionSpec,
           options.embedded,
           options.monoRepoPackages,
           pkgToCustomize.name,
         );
-        if (resolved !== undefined) {
-          pkgToCustomize.dependencies[dep] = resolved;
+        if (result) {
+          pkgToCustomize.dependencies[dep] = result.resolved;
+          if (!embeddedNames.has(dep)) {
+            pinnedResolutions[dep] = result.exact;
+          }
         }
 
         if (isPackageShared(dep, options.sharedPackages)) {
@@ -847,12 +856,15 @@ export function customizeForDynamicUse(options: {
     if (pkgToCustomize.peerDependencies) {
       for (const dep in pkgToCustomize.peerDependencies) {
         if (!Object.prototype.hasOwnProperty.call(pkgToCustomize.peerDependencies, dep)) continue;
-        const resolved = await resolveProtocolVersion(
+        const result = await resolveProtocolVersion(
           dep, pkgToCustomize.peerDependencies[dep],
           options.embedded, options.monoRepoPackages, pkgToCustomize.name,
         );
-        if (resolved !== undefined) {
-          pkgToCustomize.peerDependencies[dep] = resolved;
+        if (result) {
+          pkgToCustomize.peerDependencies[dep] = result.resolved;
+          if (!embeddedNames.has(dep)) {
+            pinnedResolutions[dep] = result.exact;
+          }
         }
       }
     }
@@ -883,6 +895,9 @@ export function customizeForDynamicUse(options: {
       ...overrides,
       ...(options.additionalOverrides || {}),
     };
+    // Pin resolved workspace:/backstage: packages to exact versions in resolutions
+    // to prevent npm version drift during yarn install --no-immutable.
+    // Existing resolutions and additionalResolutions (embedded file: refs) take precedence.
     const resolutions = (pkgToCustomize as any).resolutions || {};
     (pkgToCustomize as any).resolutions = {
       // The following lines are a workaround for the fact that the @aws-sdk/util-utf8-browser package
@@ -891,6 +906,7 @@ export function customizeForDynamicUse(options: {
       //
       // See https://github.com/aws/aws-sdk-js-v3/issues/5305.
       '@aws-sdk/util-utf8-browser': 'npm:@smithy/util-utf8@~2',
+      ...pinnedResolutions,
       ...resolutions,
       ...(options.additionalResolutions || {}),
     };

--- a/src/commands/export-dynamic-plugin/backend.ts
+++ b/src/commands/export-dynamic-plugin/backend.ts
@@ -682,6 +682,84 @@ function checkWorkspacePackageVersion(
   );
 }
 
+/**
+ * Resolves workspace: and backstage: protocol version specs to concrete versions.
+ *
+ * - workspace:^ / workspace:~ / workspace:* => lookup in embedded, then monoRepoPackages
+ * - backstage:^ => delegate to resolveBackstageVersion()
+ * - anything else => undefined (no transformation needed)
+ *
+ * Preserves the range prefix: workspace:^ => ^1.5.0, workspace:~ => ~1.5.0,
+ * workspace:* => 1.5.0, backstage:^ => ^1.5.0.
+ */
+async function resolveProtocolVersion(
+  dep: string,
+  versionSpec: string,
+  embedded: ResolvedEmbedded[],
+  monoRepoPackages: Packages | undefined,
+  contextPkgName: string,
+): Promise<string | undefined> {
+  if (versionSpec.startsWith('workspace:')) {
+    let resolvedVersion: string | undefined;
+    const rangeSpecifier = versionSpec.replace(/^workspace:/, '');
+    const embeddedDep = embedded.find(
+      e =>
+        e.packageName === dep &&
+        checkWorkspacePackageVersion(versionSpec, e),
+    );
+    if (embeddedDep) {
+      resolvedVersion = embeddedDep.version;
+    } else if (monoRepoPackages) {
+      const relatedMonoRepoPackages = monoRepoPackages.packages.filter(
+        p => p.packageJson.name === dep,
+      );
+      if (relatedMonoRepoPackages.length > 1) {
+        throw new Error(
+          `Two packages named ${chalk.cyan(
+            dep,
+          )} exist in the monorepo structure: this is not supported.`,
+        );
+      }
+      if (
+        relatedMonoRepoPackages.length === 1 &&
+        checkWorkspacePackageVersion(versionSpec, {
+          dir: relatedMonoRepoPackages[0].dir,
+          version: relatedMonoRepoPackages[0].packageJson.version,
+        })
+      ) {
+        resolvedVersion = relatedMonoRepoPackages[0].packageJson.version;
+      }
+    }
+
+    if (!resolvedVersion) {
+      throw new Error(
+        `Workspace dependency ${chalk.cyan(dep)} of package ${chalk.cyan(
+          contextPkgName,
+        )} doesn't exist in the monorepo structure: maybe you should embed it ?`,
+      );
+    }
+
+    if (rangeSpecifier === '^' || rangeSpecifier === '~') {
+      resolvedVersion = rangeSpecifier + resolvedVersion;
+    }
+    return resolvedVersion;
+  }
+
+  if (isBackstageVersionSpec(versionSpec)) {
+    const resolvedVersion = await resolveBackstageVersion(dep, versionSpec);
+    if (resolvedVersion) {
+      Task.log(
+        `  resolving ${chalk.cyan(dep)} from ${chalk.yellow(
+          versionSpec,
+        )} to ${chalk.green(resolvedVersion)}`,
+      );
+      return resolvedVersion;
+    }
+  }
+
+  return undefined;
+}
+
 export function customizeForDynamicUse(options: {
   embedded: ResolvedEmbedded[];
   isYarnV1: boolean;
@@ -713,6 +791,7 @@ export function customizeForDynamicUse(options: {
       f => !f.startsWith('dist-dynamic/'),
     );
 
+    // Resolve workspace: and backstage: in dependencies
     if (pkgToCustomize.dependencies) {
       for (const dep in pkgToCustomize.dependencies) {
         if (
@@ -725,68 +804,15 @@ export function customizeForDynamicUse(options: {
         }
 
         const dependencyVersionSpec = pkgToCustomize.dependencies[dep];
-        if (dependencyVersionSpec.startsWith('workspace:')) {
-          let resolvedVersion: string | undefined;
-          const rangeSpecifier = dependencyVersionSpec.replace(
-            /^workspace:/,
-            '',
-          );
-          const embeddedDep = options.embedded.find(
-            e =>
-              e.packageName === dep &&
-              checkWorkspacePackageVersion(dependencyVersionSpec, e),
-          );
-          if (embeddedDep) {
-            resolvedVersion = embeddedDep.version;
-          } else if (options.monoRepoPackages) {
-            const relatedMonoRepoPackages =
-              options.monoRepoPackages.packages.filter(
-                p => p.packageJson.name === dep,
-              );
-            if (relatedMonoRepoPackages.length > 1) {
-              throw new Error(
-                `Two packages named ${chalk.cyan(
-                  dep,
-                )} exist in the monorepo structure: this is not supported.`,
-              );
-            }
-            if (
-              relatedMonoRepoPackages.length === 1 &&
-              checkWorkspacePackageVersion(dependencyVersionSpec, {
-                dir: relatedMonoRepoPackages[0].dir,
-                version: relatedMonoRepoPackages[0].packageJson.version,
-              })
-            ) {
-              resolvedVersion = relatedMonoRepoPackages[0].packageJson.version;
-            }
-          }
-
-          if (!resolvedVersion) {
-            throw new Error(
-              `Workspace dependency ${chalk.cyan(dep)} of package ${chalk.cyan(
-                pkgToCustomize.name,
-              )} doesn't exist in the monorepo structure: maybe you should embed it ?`,
-            );
-          }
-
-          if (rangeSpecifier === '^' || rangeSpecifier === '~') {
-            resolvedVersion = rangeSpecifier + resolvedVersion;
-          }
-          pkgToCustomize.dependencies[dep] = resolvedVersion;
-        } else if (isBackstageVersionSpec(dependencyVersionSpec)) {
-          // Handle backstage:^ protocol - resolve to concrete version from release manifest
-          const resolvedVersion = await resolveBackstageVersion(
-            dep,
-            dependencyVersionSpec,
-          );
-          if (resolvedVersion) {
-            Task.log(
-              `  resolving ${chalk.cyan(dep)} from ${chalk.yellow(
-                dependencyVersionSpec,
-              )} to ${chalk.green(resolvedVersion)}`,
-            );
-            pkgToCustomize.dependencies[dep] = resolvedVersion;
-          }
+        const resolved = await resolveProtocolVersion(
+          dep,
+          dependencyVersionSpec,
+          options.embedded,
+          options.monoRepoPackages,
+          pkgToCustomize.name,
+        );
+        if (resolved !== undefined) {
+          pkgToCustomize.dependencies[dep] = resolved;
         }
 
         if (isPackageShared(dep, options.sharedPackages)) {
@@ -813,6 +839,20 @@ export function customizeForDynamicUse(options: {
             pkgToCustomize.dependencies[dep] =
               `file:./${embeddedPackageRelativePath(embeddedDep)}`;
           }
+        }
+      }
+    }
+
+    // Resolve workspace: and backstage: in pre-existing peerDependencies
+    if (pkgToCustomize.peerDependencies) {
+      for (const dep in pkgToCustomize.peerDependencies) {
+        if (!Object.prototype.hasOwnProperty.call(pkgToCustomize.peerDependencies, dep)) continue;
+        const resolved = await resolveProtocolVersion(
+          dep, pkgToCustomize.peerDependencies[dep],
+          options.embedded, options.monoRepoPackages, pkgToCustomize.name,
+        );
+        if (resolved !== undefined) {
+          pkgToCustomize.peerDependencies[dep] = resolved;
         }
       }
     }

--- a/src/commands/export-dynamic-plugin/backend.ts
+++ b/src/commands/export-dynamic-plugin/backend.ts
@@ -869,6 +869,44 @@ export function customizeForDynamicUse(options: {
       }
     }
 
+    // Pin transitive workspace:/backstage: deps reachable from direct deps.
+    // Without pinning, yarn resolves these from npm (workspace: lockfile entries
+    // cannot seed npm: entries in dist-dynamic), causing version drift.
+    if (options.monoRepoPackages) {
+      const wsPackagesByName = new Map(
+        options.monoRepoPackages.packages.map(p => [p.packageJson.name, p]),
+      );
+      const queue = Object.keys(pinnedResolutions);
+      const visited = new Set<string>(queue);
+
+      while (queue.length > 0) {
+        const pkgName = queue.pop()!;
+        const wsPkg = wsPackagesByName.get(pkgName);
+        if (!wsPkg) continue;
+
+        const allDeps: Record<string, string> = {
+          ...wsPkg.packageJson.dependencies,
+          ...wsPkg.packageJson.peerDependencies,
+        };
+        for (const [depName, depVersion] of Object.entries(allDeps)) {
+          if (visited.has(depName)) continue;
+          visited.add(depName);
+
+          const isProtocol =
+            depVersion.startsWith('workspace:') ||
+            depVersion.startsWith('backstage:');
+          if (!isProtocol) continue;
+          if (embeddedNames.has(depName)) continue;
+
+          const depPkg = wsPackagesByName.get(depName);
+          if (depPkg) {
+            pinnedResolutions[depName] = depPkg.packageJson.version;
+            queue.push(depName);
+          }
+        }
+      }
+    }
+
     // We remove devDependencies here since we want the dynamic plugin derived package
     // to get only production dependencies, and no transitive dependencies, in both
     // the node_modules sub-folder and yarn.lock file in `dist-dynamic`.

--- a/src/commands/export-dynamic-plugin/backend.ts
+++ b/src/commands/export-dynamic-plugin/backend.ts
@@ -704,8 +704,7 @@ async function resolveProtocolVersion(
     const rangeSpecifier = versionSpec.replace(/^workspace:/, '');
     const embeddedDep = embedded.find(
       e =>
-        e.packageName === dep &&
-        checkWorkspacePackageVersion(versionSpec, e),
+        e.packageName === dep && checkWorkspacePackageVersion(versionSpec, e),
     );
     if (embeddedDep) {
       resolvedVersion = embeddedDep.version;
@@ -855,10 +854,19 @@ export function customizeForDynamicUse(options: {
     // Resolve workspace: and backstage: in pre-existing peerDependencies
     if (pkgToCustomize.peerDependencies) {
       for (const dep in pkgToCustomize.peerDependencies) {
-        if (!Object.prototype.hasOwnProperty.call(pkgToCustomize.peerDependencies, dep)) continue;
+        if (
+          !Object.prototype.hasOwnProperty.call(
+            pkgToCustomize.peerDependencies,
+            dep,
+          )
+        )
+          continue;
         const result = await resolveProtocolVersion(
-          dep, pkgToCustomize.peerDependencies[dep],
-          options.embedded, options.monoRepoPackages, pkgToCustomize.name,
+          dep,
+          pkgToCustomize.peerDependencies[dep],
+          options.embedded,
+          options.monoRepoPackages,
+          pkgToCustomize.name,
         );
         if (result) {
           pkgToCustomize.peerDependencies[dep] = result.resolved;


### PR DESCRIPTION
### Description

The `customizeForDynamicUse()` function only resolves `workspace:` and `backstage:` protocol
version specifiers in `dependencies`, ignoring `peerDependencies`. Raw protocol specifiers
in `peerDependencies` end up verbatim in the exported `dist-dynamic/package.json`, which is
invalid and causes install failures.

Additionally, resolved versions are not pinned in `resolutions`, allowing Yarn to pick
different versions during `yarn install --no-immutable` and causing dependency drift.

### Fixes

https://redhat.atlassian.net/browse/RHDHBUGS-3124

### Changes

- Extract protocol resolution into a shared `resolveProtocolVersion()` helper returning
  both the range-prefixed version (`^1.5.0`) and the exact version (`1.5.0`)
- Apply resolution to both `dependencies` and `peerDependencies`
- Pin resolved non-embedded packages to their exact versions in `resolutions`
  (existing resolutions and embedded `file:` refs take precedence)