### PR TITLE
chore(agent-readiness): bootstrap basic AGENTS.md and minor repo updates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx prettier --ignore-unknown --write $CLAUDE_FILE_PATH 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,17 @@ dist-types
 
 # Temporary change files created by Vim
 *.swp
+*.swo
+
+# TypeScript build info
+*.tsbuildinfo
+
+# npm cache
+.npm/
+
+# IDE directories
+.vscode/
+.idea/
 
 # MkDocs build output
 site

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # rhdh-cli
 
 ## Build & Test Commands
+
 - Build: `yarn build`
 - Test all: `yarn test`
 - Test single file: `yarn test -- --testPathPattern=src/path/to/file.test.ts`
@@ -11,21 +12,25 @@
 - Prettier check: `yarn prettier:check` (fix: `yarn prettier:fix`)
 
 ## Key Conventions
+
 <!-- Add 2-3 conventions an agent couldn't discover by reading the code —
      e.g. co-location rules, naming patterns, file organisation decisions. -->
 
 ## Architecture
+
 <!-- Add non-obvious architectural decisions or places where things live
      unexpectedly — e.g. why a module lives where it does, key abstractions,
      anything that would surprise a reader unfamiliar with the project. -->
 
 ## Pattern References
+
 <!-- Point agents to 3-5 real examples for the most common change types.
      Example:
      - New CLI command: follow the pattern in `src/commands/config/show.ts`
      - New lib utility: see `src/lib/parallel.ts` as reference -->
 
 ## PR Conventions
+
 - PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) — enforced by CI (`pr-semantic.yaml`)
 - Allowed types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `revert`
 - Subjects must not start with an uppercase character

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# rhdh-cli
+
+## Build & Test Commands
+- Build: `yarn build`
+- Test all: `yarn test`
+- Test single file: `yarn test -- --testPathPattern=src/path/to/file.test.ts`
+- Lint: `yarn lint:check` (fix: `yarn lint:fix`)
+- Lint single file: `npx eslint src/path/to/file.ts`
+- Type check (full project): `yarn tsc`
+- Type check single file: not supported — `tsconfig.json` extends Backstage's base config, so `tsc` must run project-wide; use `yarn tsc` and check for errors in the target file
+- Prettier check: `yarn prettier:check` (fix: `yarn prettier:fix`)
+
+## Key Conventions
+<!-- Add 2-3 conventions an agent couldn't discover by reading the code —
+     e.g. co-location rules, naming patterns, file organisation decisions. -->
+
+## Architecture
+<!-- Add non-obvious architectural decisions or places where things live
+     unexpectedly — e.g. why a module lives where it does, key abstractions,
+     anything that would surprise a reader unfamiliar with the project. -->
+
+## Pattern References
+<!-- Point agents to 3-5 real examples for the most common change types.
+     Example:
+     - New CLI command: follow the pattern in `src/commands/config/show.ts`
+     - New lib utility: see `src/lib/parallel.ts` as reference -->
+
+## PR Conventions
+- PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) — enforced by CI (`pr-semantic.yaml`)
+- Allowed types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `revert`
+- Subjects must not start with an uppercase character
+- Agent-assisted commits should include an `Assisted-by: <model>` footer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Description

Ran the agent-ready (https://github.com/redhat-developer/rhdh-skill/blob/main/skills/agent-ready/SKILL.md) skill against the repository, to address some gaps called out by the https://github.com/ambient-code/agentready CLI (to assess an individual repository's readiness to be consumed by agents). 

- Adds an AGENTS.md / CLAUDE.md with basic one-line build and test commands, and a link to some repo docs that could be found
    - **To the maintainers:** I recommend populating the Key convention and Architecture sections for stuff that isn't immediately obvious to an agent
        - **Do not** auto generate this information, as it can actively harm agent effectiveness
- A couple minor updates to the repo and a claude rule to improve agent consumption

## Which issue(s) does this PR fix or relate to

N/A, but see https://docs.google.com/spreadsheets/d/1Gk3nDQFJ2PBaaPiMZ3naJqAWf-nmL14OwK-Y83k7cuc/edit for more information

## PR acceptance criteria

- [ ] Tests
- [x] Documentation