### PR TITLE
fix: add missing `backstage.features` filed for standard Module federation assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Added missing `backstage.features` field to generated `dist-dynamic/package.json` files in case of standard Module Federation asset generation. 
+- Added missing `backstage.features` field to generated `dist-dynamic/package.json` files in case of standard Module Federation asset generation.
 
 ## 1.11.0 - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@red-hat-developer-hub/cli` are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.11.3 - 2026-07-20
+
+### Fixed
+
+- Added missing `backstage.features` field to generated `dist-dynamic/package.json` files in case of standard Module Federation asset generation. 
+
 ## 1.11.0 - 2026-05-08
 
 ### Fixed

--- a/e2e-tests/community-plugins-build-package.test.ts
+++ b/e2e-tests/community-plugins-build-package.test.ts
@@ -103,6 +103,9 @@ describe('export and package backstage-community plugin', () => {
       const packageJsonPath = path.join(getFullPluginPath(), 'package.json');
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
       const role = packageJson.backstage?.role;
+      const expectedFeatures = expect.objectContaining({
+        './alpha': '@backstage/FrontendPlugin',
+      });
       if (role === 'frontend-plugin') {
         // eslint-disable-next-line jest/no-conditional-expect
         expect(
@@ -113,6 +116,15 @@ describe('export and package backstage-community plugin', () => {
             ),
           ),
         ).toEqual(true);
+
+        const distDynamicPkg = JSON.parse(
+          fs.readFileSync(
+            path.join(getFullPluginPath(), 'dist-dynamic/package.json'),
+            'utf-8',
+          ),
+        );
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(distDynamicPkg.backstage?.features).toEqual(expectedFeatures);
       }
     });
 

--- a/e2e-tests/rhdh-plugins-build-package.test.ts
+++ b/e2e-tests/rhdh-plugins-build-package.test.ts
@@ -103,6 +103,9 @@ describe('export and package rhdh-plugins scorecard workspace plugin', () => {
       const packageJsonPath = path.join(getFullPluginPath(), 'package.json');
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
       const role = packageJson.backstage?.role;
+      const expectedFeatures = expect.objectContaining({
+        './alpha': '@backstage/FrontendPlugin',
+      });
       if (role === 'frontend-plugin') {
         // eslint-disable-next-line jest/no-conditional-expect
         expect(
@@ -113,6 +116,15 @@ describe('export and package rhdh-plugins scorecard workspace plugin', () => {
             ),
           ),
         ).toEqual(true);
+
+        const distDynamicPkg = JSON.parse(
+          fs.readFileSync(
+            path.join(getFullPluginPath(), 'dist-dynamic/package.json'),
+            'utf-8',
+          ),
+        );
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(distDynamicPkg.backstage?.features).toEqual(expectedFeatures);
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "@backstage/config-loader": "~1.10.12"
   },
   "peerDependencies": {
-    "@microsoft/api-extractor": "^7.21.2"
+    "@microsoft/api-extractor": "^7.21.2",
+    "ts-morph": "*"
   },
   "peerDependenciesMeta": {
     "@microsoft/api-extractor": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-hat-developer-hub/cli",
   "description": "CLI for developing Backstage plugins and apps",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "publishConfig": {
     "access": "public"
   },

--- a/scripts/backstage-types-config.json
+++ b/scripts/backstage-types-config.json
@@ -7,6 +7,14 @@
     {
       "name": "@backstage/cli-module-build/dist/lib/buildBackend.cjs.js",
       "types": "dist-types/packages/cli-module-build/src/lib/buildBackend.d.ts"
+    },
+    {
+      "name": "@backstage/cli-module-build/dist/lib/typeDistProject.cjs.js",
+      "types": "dist-types/packages/cli-module-build/src/lib/typeDistProject.d.ts"
+    },
+    {
+      "name": "@backstage/cli-module-build/dist/lib/entryPoints.cjs.js",
+      "types": "dist-types/packages/cli-module-build/src/lib/entryPoints.d.ts"
     }
   ]
 }

--- a/src/commands/export-dynamic-plugin/features.ts
+++ b/src/commands/export-dynamic-plugin/features.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BackstagePackageFeatureType,
+  BackstagePackageJson,
+} from '@backstage/cli-node';
+import { readEntryPoints } from '@backstage/cli-module-build/dist/lib/entryPoints.cjs.js';
+import {
+  createTypeDistProject,
+  getEntryPointDefaultFeatureType,
+} from '@backstage/cli-module-build/dist/lib/typeDistProject.cjs.js';
+
+import chalk from 'chalk';
+
+import { Task } from '../../lib/tasks';
+
+/**
+ * Detects backstage feature types for all entry points in a package by
+ * analyzing the default export's $$type using ts-morph type resolution.
+ *
+ * Mirrors the feature detection in upstream Backstage's `productionPack`
+ * (packages/cli-module-build/src/lib/packager/productionPack.ts), which
+ * populates `backstage.features` in package.json during `backstage-cli pack`.
+ * Since rhdh-cli's forked `productionPack` predates that addition, we
+ * perform the same detection here as a separate step.
+ *
+ * Returns a map of entry point mount to feature type, or undefined if
+ * no features were detected.
+ */
+export async function detectBackstageFeatures(
+  originalPkg: BackstagePackageJson,
+  packageDir: string,
+): Promise<Record<string, BackstagePackageFeatureType> | undefined> {
+  const role = originalPkg.backstage?.role;
+  if (!role) {
+    return undefined;
+  }
+
+  const project = await createTypeDistProject();
+  const entryPoints = readEntryPoints(originalPkg);
+  const features: Record<string, BackstagePackageFeatureType> = {};
+
+  for (const ep of entryPoints) {
+    if (ep.mount === './package.json') {
+      continue;
+    }
+
+    try {
+      const featureType = getEntryPointDefaultFeatureType(
+        role,
+        packageDir,
+        project,
+        ep.path,
+      );
+
+      if (featureType) {
+        features[ep.mount] = featureType;
+        Task.log(
+          `  detected backstage feature: ${chalk.cyan(ep.mount)} => ${chalk.green(featureType)}`,
+        );
+      }
+    } catch (error) {
+      Task.log(
+        chalk.yellow(
+          `Failed to detect backstage feature type for entry point ${chalk.cyan(ep.mount)}: ${error}`,
+        ),
+      );
+    }
+  }
+
+  return Object.keys(features).length > 0 ? features : undefined;
+}

--- a/src/commands/export-dynamic-plugin/frontend.ts
+++ b/src/commands/export-dynamic-plugin/frontend.ts
@@ -29,6 +29,7 @@ import { productionPack } from '../../lib/packager/productionPack';
 import { paths } from '../../lib/paths';
 import { Task } from '../../lib/tasks';
 import { customizeForDynamicUse } from './backend';
+import { detectBackstageFeatures } from './features';
 
 function isTruthyCiEnv(value: string | undefined): boolean {
   if (value === undefined) {
@@ -42,12 +43,13 @@ export async function frontend(
   _: PackageRoleInfo,
   opts: OptionValues,
 ): Promise<string> {
+  const originalPkg = await fs.readJson(paths.resolveTarget('package.json'));
   const {
     name,
     version,
     scalprum: scalprumInline,
     files,
-  } = await fs.readJson(paths.resolveTarget('package.json'));
+  } = originalPkg;
 
   if (!opts.generateScalprumAssets && !opts.generateModuleFederationAssets) {
     throw new Error(
@@ -126,6 +128,10 @@ export async function frontend(
   ) {
     files.push('dist-scalprum');
   }
+  const detectedFeatures = opts.generateModuleFederationAssets
+    ? await detectBackstageFeatures(originalPkg, paths.targetDir)
+    : undefined;
+
   const monoRepoPackages = await getPackages(paths.targetDir);
   await customizeForDynamicUse({
     embedded: [],
@@ -141,6 +147,12 @@ export async function frontend(
       scripts: {},
       files,
     },
+    after: detectedFeatures
+      ? pkg => {
+          pkg.backstage = pkg.backstage ?? {};
+          pkg.backstage.features = detectedFeatures;
+        }
+      : undefined,
   })(path.resolve(target, 'package.json'));
 
   if (opts.generateScalprumAssets) {

--- a/src/commands/export-dynamic-plugin/frontend.ts
+++ b/src/commands/export-dynamic-plugin/frontend.ts
@@ -44,12 +44,7 @@ export async function frontend(
   opts: OptionValues,
 ): Promise<string> {
   const originalPkg = await fs.readJson(paths.resolveTarget('package.json'));
-  const {
-    name,
-    version,
-    scalprum: scalprumInline,
-    files,
-  } = originalPkg;
+  const { name, version, scalprum: scalprumInline, files } = originalPkg;
 
   if (!opts.generateScalprumAssets && !opts.generateModuleFederationAssets) {
     throw new Error(

--- a/src/generated/backstage-cli-types.d.ts
+++ b/src/generated/backstage-cli-types.d.ts
@@ -1,4 +1,3 @@
-
 /*
  * Auto-generated TypeScript declarations for @backstage/cli-module-build
  * Generated from @backstage/cli version: 0.36.3
@@ -11,53 +10,59 @@
  * (same commit as the pinned @backstage/cli), via root `yarn tsc`.
  */
 
-
 declare module '@backstage/cli-module-build/dist/lib/buildFrontend.cjs.js' {
   interface BuildAppOptions {
-      targetDir: string;
-      writeStats: boolean;
-      configPaths: string[];
-      isModuleFederationRemote?: boolean;
-      webpack?: typeof import('webpack');
+    targetDir: string;
+    writeStats: boolean;
+    configPaths: string[];
+    isModuleFederationRemote?: boolean;
+    webpack?: typeof import('webpack');
   }
-  export declare function buildFrontend(options: BuildAppOptions): Promise<void>;
+  export declare function buildFrontend(
+    options: BuildAppOptions,
+  ): Promise<void>;
   export {};
-  
 }
-
 
 declare module '@backstage/cli-module-build/dist/lib/buildBackend.cjs.js' {
   interface BuildBackendOptions {
-      targetDir: string;
-      skipBuildDependencies: boolean;
-      configPaths?: string[];
-      minify?: boolean;
+    targetDir: string;
+    skipBuildDependencies: boolean;
+    configPaths?: string[];
+    minify?: boolean;
   }
-  export declare function buildBackend(options: BuildBackendOptions): Promise<void>;
+  export declare function buildBackend(
+    options: BuildBackendOptions,
+  ): Promise<void>;
   export {};
-  
 }
 
-
 declare module '@backstage/cli-module-build/dist/lib/typeDistProject.cjs.js' {
-  import { BackstagePackageFeatureType, PackageRole } from '@backstage/cli-node';
+  import {
+    BackstagePackageFeatureType,
+    PackageRole,
+  } from '@backstage/cli-node';
   import { Project } from 'ts-morph';
 
   export declare const createTypeDistProject: () => Promise<Project>;
-  export declare const getEntryPointDefaultFeatureType: (role: PackageRole, packageDir: string, project: Project, entryPoint: string) => BackstagePackageFeatureType | null;
-  
+  export declare const getEntryPointDefaultFeatureType: (
+    role: PackageRole,
+    packageDir: string,
+    project: Project,
+    entryPoint: string,
+  ) => BackstagePackageFeatureType | null;
 }
-
 
 declare module '@backstage/cli-module-build/dist/lib/entryPoints.cjs.js' {
   import { BackstagePackageJson } from '@backstage/cli-node';
 
   export interface EntryPoint {
-      mount: string;
-      path: string;
-      name: string;
-      ext: string;
+    mount: string;
+    path: string;
+    name: string;
+    ext: string;
   }
-  export declare function readEntryPoints(pkg: BackstagePackageJson): Array<EntryPoint>;
-  
+  export declare function readEntryPoints(
+    pkg: BackstagePackageJson,
+  ): Array<EntryPoint>;
 }

--- a/src/generated/backstage-cli-types.d.ts
+++ b/src/generated/backstage-cli-types.d.ts
@@ -42,6 +42,7 @@ declare module '@backstage/cli-module-build/dist/lib/buildBackend.cjs.js' {
 declare module '@backstage/cli-module-build/dist/lib/typeDistProject.cjs.js' {
   import { BackstagePackageFeatureType, PackageRole } from '@backstage/cli-node';
   import { Project } from 'ts-morph';
+
   export declare const createTypeDistProject: () => Promise<Project>;
   export declare const getEntryPointDefaultFeatureType: (role: PackageRole, packageDir: string, project: Project, entryPoint: string) => BackstagePackageFeatureType | null;
   
@@ -50,6 +51,7 @@ declare module '@backstage/cli-module-build/dist/lib/typeDistProject.cjs.js' {
 
 declare module '@backstage/cli-module-build/dist/lib/entryPoints.cjs.js' {
   import { BackstagePackageJson } from '@backstage/cli-node';
+
   export interface EntryPoint {
       mount: string;
       path: string;

--- a/src/generated/backstage-cli-types.d.ts
+++ b/src/generated/backstage-cli-types.d.ts
@@ -38,3 +38,24 @@ declare module '@backstage/cli-module-build/dist/lib/buildBackend.cjs.js' {
   
 }
 
+
+declare module '@backstage/cli-module-build/dist/lib/typeDistProject.cjs.js' {
+  import { BackstagePackageFeatureType, PackageRole } from '@backstage/cli-node';
+  import { Project } from 'ts-morph';
+  export declare const createTypeDistProject: () => Promise<Project>;
+  export declare const getEntryPointDefaultFeatureType: (role: PackageRole, packageDir: string, project: Project, entryPoint: string) => BackstagePackageFeatureType | null;
+  
+}
+
+
+declare module '@backstage/cli-module-build/dist/lib/entryPoints.cjs.js' {
+  import { BackstagePackageJson } from '@backstage/cli-node';
+  export interface EntryPoint {
+      mount: string;
+      path: string;
+      name: string;
+      ext: string;
+  }
+  export declare function readEntryPoints(pkg: BackstagePackageJson): Array<EntryPoint>;
+  
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,6 +4915,7 @@ __metadata:
     yn: ^4.0.0
   peerDependencies:
     "@microsoft/api-extractor": ^7.21.2
+    ts-morph: "*"
   peerDependenciesMeta:
     "@microsoft/api-extractor":
       optional: true


### PR DESCRIPTION
### Summary

Implements [RHIDP-15376](https://redhat.atlassian.net/browse/RHIDP-15376).

Upstream Backstage's `backstage-cli pack` now populates `backstage.features` in `package.json` by analyzing each entry point's default export `$$type` via `ts-morph`. Since rhdh-cli's forked `productionPack` predates that addition, this PR adds the same detection as a separate step during frontend dynamic plugin export.

When `--generate-module-federation-assets` is enabled (the default), the export command now:
- Creates a `ts-morph` project and reads the package's entry points
- Detects the Backstage feature type for each entry point (e.g. `@backstage/FrontendPlugin`)
- Writes the detected features into `backstage.features` in the output `package.json`

### Changes

- **New:** `src/commands/export-dynamic-plugin/features.ts` — `detectBackstageFeatures()` utility mirroring upstream's detection logic
- **Modified:** `src/commands/export-dynamic-plugin/frontend.ts` — integrates feature detection and injects results via the `after` callback of `customizeForDynamicUse()`
- **Modified:** `scripts/backstage-types-config.json` — added type extraction config for `typeDistProject` and `entryPoints` modules
- **Regenerated:** `src/generated/backstage-cli-types.d.ts` — now includes type declarations for the new internal modules
- **Modified:** `package.json` — added `ts-morph` as a peer dependency (provided transitively by `@backstage/cli-module-build`)
- **Modified:** E2E tests — added assertions verifying `backstage.features` is populated for frontend plugins

### Test plan

- [x] Manual verification: `rhdh-cli plugin export-dynamic` on a frontend plugin produces `backstage.features` with correct feature types
- [x] E2E tests pass with new `backstage.features` assertions
- [x] `yarn tsc` passes