### PR TITLE
feat(ci): add branch selector to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,17 @@ name: Publish package to NPM
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to publish from'
+        required: true
+        default: 'main'
+        type: choice
+        options:
+          - main
+          - release-1.10
+          - release-1.9
+          - release-1.8
 
 jobs:
   version:
@@ -15,6 +26,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.branch }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -33,4 +45,9 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Publish
-        run: npm publish --access public
+        run: |
+          if [ "${{ inputs.branch }}" = "main" ]; then
+            npm publish --access public
+          else
+            npm publish --access public --tag ${{ inputs.branch }}
+          fi


### PR DESCRIPTION
## Summary
- Adds a branch selector dropdown to the publish workflow (main, release-1.10, release-1.9, release-1.8)
- Checkout uses the selected branch
- Non-main branches publish with a dist-tag matching the branch name to avoid overwriting `latest`

## Test plan
- [ ] Trigger workflow from GitHub Actions UI and verify the branch dropdown appears
- [ ] Publish from main — should use `npm publish --access public` (no tag)
- [ ] Publish from a release branch — should use `--tag <branch-name>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)