### PR TITLE
fix(ci): align npm dist-tags with GA releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -61,9 +61,9 @@ jobs:
         run: |
           if [ "${{ inputs.branch }}" = "main" ]; then
             npm publish --access public --tag next
-          # Check if the selected branch matches the auto-detected latest GA branch (highest semver release-* branch)
           elif [ "${{ inputs.branch }}" = "${{ steps.detect-ga.outputs.branch }}" ]; then
-            npm publish --access public
+            npm publish --access public --tag latest
+            npm dist-tag add "$(node -p "require('./package.json').name")@$(node -p "require('./package.json').version")" "${{ inputs.branch }}"
           else
             npm publish --access public --tag ${{ inputs.branch }}
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,9 +42,27 @@ jobs:
       - name: Update npm
         run: npm install -g npm@11
 
+      - name: Detect latest GA branch
+        id: detect-ga
+        run: |
+          # Auto-detect the latest GA release branch:
+          # 1. git ls-remote lists all remote release-* branches without cloning history
+          # 2. sed strips everything up to "release-", leaving just the version (e.g., "1.10")
+          # 3. sort -t. splits on "." and sorts each field numerically (-n), so
+          #    1.9 < 1.10 < 1.11 < 2.1 (lexicographic sort would wrongly put 1.10 before 1.9)
+          # 4. tail -1 picks the highest version
+          LATEST_GA=$(git ls-remote --heads origin 'refs/heads/release-*' \
+            | sed 's|.*refs/heads/release-||' \
+            | sort -t. -k1,1n -k2,2n \
+            | tail -1)
+          echo "branch=release-${LATEST_GA}" >> "$GITHUB_OUTPUT"
+
       - name: Publish
         run: |
           if [ "${{ inputs.branch }}" = "main" ]; then
+            npm publish --access public --tag next
+          # Check if the selected branch matches the auto-detected latest GA branch (highest semver release-* branch)
+          elif [ "${{ inputs.branch }}" = "${{ steps.detect-ga.outputs.branch }}" ]; then
             npm publish --access public
           else
             npm publish --access public --tag ${{ inputs.branch }}

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The workflow automatically assigns npm dist-tags based on the selected branch:
 | Branch | Dist-tag | Example |
 | --- | --- | --- |
 | `main` | `next` | `npm install @red-hat-developer-hub/cli@next` |
-| Latest GA release branch (auto-detected) | `latest` | `npm install @red-hat-developer-hub/cli@latest` |
+| Latest GA release branch (auto-detected) | `latest` + branch name | `npm install @red-hat-developer-hub/cli@latest` or `@release-1.10` |
 | Older release branches | Branch name (e.g., `release-1.9`) | `npm install @red-hat-developer-hub/cli@release-1.9` |
 
 The latest GA branch is auto-detected as the `release-*` branch with the highest semver version. Plugin builders targeting a specific RHDH version should use a semver range (e.g., `~1.10.0`) or the corresponding branch tag rather than `latest`.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,19 @@ Publishing is done using [Publish Package to NPM](.github/workflows/publish.yaml
 
 **Make sure not to release MINOR or MAJOR version that are not aligned with the corresponding RHDH release.**
 
-This workflow is **not** currently triggered automatically. It needs to be run manually from the [Actions tab](https://github.com/redhat-developer/rhdh-cli/actions/workflows/publish.yaml) in the GitHub repository.
+This workflow is **not** currently triggered automatically. It needs to be run manually from the [Actions tab](https://github.com/redhat-developer/rhdh-cli/actions/workflows/publish.yaml) in the GitHub repository. Always run the workflow from the `main` branch (the "Use workflow from" dropdown) and select the target release branch via the `branch` input parameter. This ensures the latest workflow definition is used.
+
+#### NPM dist-tags
+
+The workflow automatically assigns npm dist-tags based on the selected branch:
+
+| Branch | Dist-tag | Example |
+| --- | --- | --- |
+| `main` | `next` | `npm install @red-hat-developer-hub/cli@next` |
+| Latest GA release branch (auto-detected) | `latest` | `npm install @red-hat-developer-hub/cli@latest` |
+| Older release branches | Branch name (e.g., `release-1.9`) | `npm install @red-hat-developer-hub/cli@release-1.9` |
+
+The latest GA branch is auto-detected as the `release-*` branch with the highest semver version. Plugin builders targeting a specific RHDH version should use a semver range (e.g., `~1.10.0`) or the corresponding branch tag rather than `latest`.
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ This workflow is **not** currently triggered automatically. It needs to be run m
 
 The workflow automatically assigns npm dist-tags based on the selected branch:
 
-| Branch | Dist-tag | Example |
-| --- | --- | --- |
-| `main` | `next` | `npm install @red-hat-developer-hub/cli@next` |
-| Latest GA release branch (auto-detected) | `latest` + branch name | `npm install @red-hat-developer-hub/cli@latest` or `@release-1.10` |
-| Older release branches | Branch name (e.g., `release-1.9`) | `npm install @red-hat-developer-hub/cli@release-1.9` |
+| Branch                                   | Dist-tag                          | Example                                                            |
+| ---------------------------------------- | --------------------------------- | ------------------------------------------------------------------ |
+| `main`                                   | `next`                            | `npm install @red-hat-developer-hub/cli@next`                      |
+| Latest GA release branch (auto-detected) | `latest` + branch name            | `npm install @red-hat-developer-hub/cli@latest` or `@release-1.10` |
+| Older release branches                   | Branch name (e.g., `release-1.9`) | `npm install @red-hat-developer-hub/cli@release-1.9`               |
 
 The latest GA branch is auto-detected as the `release-*` branch with the highest semver version. Plugin builders targeting a specific RHDH version should use a semver range (e.g., `~1.10.0`) or the corresponding branch tag rather than `latest`.
 


### PR DESCRIPTION
## Summary

- Publishing from `main` now uses `--tag next` instead of `latest`
- The `latest` dist-tag is reserved for the auto-detected highest semver release branch (e.g., `release-1.10`), matching the convention used for catalog images and quay tags
- Older release branches (e.g., `release-1.9`) continue to use their branch name as the dist-tag

## How it works

A new "Detect latest GA branch" step uses `git ls-remote` to list all `release-*` branches, sorts them numerically by semver, and picks the highest one. The publish step then:
- `main` → `npm publish --tag next`
- Highest release branch → `npm publish` (defaults to `latest`)
- Older release branches → `npm publish --tag <branch-name>`

## After merge

Run the publish workflow once from `release-1.10` to reclaim the `latest` tag from the current 1.11.x pointer.

## Test plan

- [ ] Verify workflow YAML syntax is valid
- [ ] Trigger publish from `release-1.10` → should publish as `latest`
- [ ] Trigger publish from `main` → should publish as `next`
- [ ] Trigger publish from `release-1.9` → should publish as `release-1.9`