### PR TITLE
chore: bump @red-hat-developer-hub/cli to 2.0.1

### DIFF
--- a/.changeset/clever-berries-judge.md
+++ b/.changeset/clever-berries-judge.md
@@ -1,5 +1,0 @@
----
-'@red-hat-developer-hub/cli': patch
----
-
-fix: resolve `workspace:/backstage/` protocol specifiers in `peerDependencies` and pin resolved versions in `resolutions` to prevent dependency drift

--- a/.changeset/mean-shrimps-beg.md
+++ b/.changeset/mean-shrimps-beg.md
@@ -1,5 +1,0 @@
----
-'@red-hat-developer-hub/cli': patch
----
-
-chore: update @backstage/cli to 0.35.4

--- a/.changeset/puny-dryers-write.md
+++ b/.changeset/puny-dryers-write.md
@@ -1,5 +1,0 @@
----
-'@red-hat-developer-hub/cli': patch
----
-
-chore: trap for yarn install failure and echo file in /tmp folder to console if it failed; also break on error instead of continuing (RHDHBUGS-2819)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `@red-hat-developer-hub/cli` are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.1 - 2026-08-07
+
+### Fixed
+
+- Resolve `workspace:` / `backstage:` protocol specifiers in `peerDependencies` and pin resolved versions in `resolutions` to prevent dependency drift.
+- Trap yarn install failures, surface `/tmp` install logs, and stop on error instead of continuing ([RHDHBUGS-2819](https://redhat.atlassian.net/browse/RHDHBUGS-2819)).
+
+### Changed
+
+- Bump Yarn Berry from 3.8.6 to 4.17.1 and Node baseline to 24 ([#159](https://github.com/redhat-developer/rhdh-cli/pull/159)).
+- Update `@backstage/cli` to 0.35.4.
+
 ## 1.11.4 - 2026-07-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@red-hat-developer-hub/cli",
   "description": "CLI for developing Backstage plugins and apps",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Bump package version **2.0.0 → 2.0.1**
- Consume pending patch changesets and refresh `CHANGELOG.md` (incl. Yarn 4.17.1 / Node 24 from #159)

## Test plan
- [ ] CI green
- [ ] After merge: run **Publish package to NPM** workflow on `main` → `@red-hat-developer-hub/cli@2.0.1` with `next` dist-tag
- [ ] `npm view @red-hat-developer-hub/cli@2.0.1 version`

Ref: https://redhat.atlassian.net/browse/RHIDP-16074

Generated-by: cursor

Made with [Cursor](https://cursor.com)